### PR TITLE
Automatic update of 6 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -10,7 +10,10 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
6 packages were updated in 2 projects:
`Microsoft.NET.Test.Sdk`, `Microsoft.Identity.Client`, `Microsoft.Azure.ServiceBus`, `coverlet.collector`, `MSTest.TestAdapter`, `MSTest.TestFramework`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.5.0` from `16.2.0`
`Microsoft.NET.Test.Sdk 16.5.0` was published at `2020-02-05T08:34:13Z`, 2 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Microsoft.NET.Test.Sdk` `16.5.0` from `16.2.0`

[Microsoft.NET.Test.Sdk 16.5.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.5.0)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.11.0` from `4.6.0`
`Microsoft.Identity.Client 4.11.0` was published at `2020-04-03T22:35:42Z`, 11 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.11.0` from `4.6.0`

[Microsoft.Identity.Client 4.11.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.11.0)

NuKeeper has generated a minor update of `Microsoft.Azure.ServiceBus` to `4.1.2` from `4.0.0`
`Microsoft.Azure.ServiceBus 4.1.2` was published at `2020-03-03T22:57:28Z`, 1 month ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `4.1.2` from `4.0.0`

[Microsoft.Azure.ServiceBus 4.1.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/4.1.2)

NuKeeper has generated a minor update of `coverlet.collector` to `1.2.1` from `1.0.1`
`coverlet.collector 1.2.1` was published at `2020-04-02T18:05:03Z`, 12 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `coverlet.collector` `1.2.1` from `1.0.1`

[coverlet.collector 1.2.1 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/1.2.1)

NuKeeper has generated a minor update of `MSTest.TestAdapter` to `2.1.1` from `2.0.0`
`MSTest.TestAdapter 2.1.1` was published at `2020-04-01T08:19:03Z`, 13 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestAdapter` `2.1.1` from `2.0.0`

[MSTest.TestAdapter 2.1.1 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.1)

NuKeeper has generated a minor update of `MSTest.TestFramework` to `2.1.1` from `2.0.0`
`MSTest.TestFramework 2.1.1` was published at `2020-04-01T08:20:23Z`, 13 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestFramework` `2.1.1` from `2.0.0`

[MSTest.TestFramework 2.1.1 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
