### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
   </ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Graph`, `Microsoft.NET.Sdk.Functions`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Graph` to `3.3.0` from `1.20.0`
`Microsoft.Graph 3.3.0` was published at `2020-04-14T20:26:53Z`, 7 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.3.0` from `1.20.0`

[Microsoft.Graph 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.3.0)

NuKeeper has generated a major update of `Microsoft.NET.Sdk.Functions` to `3.0.6` from `1.0.29`
`Microsoft.NET.Sdk.Functions 3.0.6` was published at `2020-04-14T21:04:46Z`, 7 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.6` from `1.0.29`

[Microsoft.NET.Sdk.Functions 3.0.6 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.6)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
