### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
   </ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />


### PR DESCRIPTION
4 packages were updated in 1 project:
`Microsoft.Graph`, `Microsoft.NET.Sdk.Functions`, `Microsoft.Identity.Client`, `Microsoft.Azure.ServiceBus`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Graph` to `3.3.0` from `1.20.0`
`Microsoft.Graph 3.3.0` was published at `2020-04-14T20:26:53Z`, 16 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.3.0` from `1.20.0`

[Microsoft.Graph 3.3.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.3.0)

NuKeeper has generated a major update of `Microsoft.NET.Sdk.Functions` to `3.0.6` from `1.0.29`
`Microsoft.NET.Sdk.Functions 3.0.6` was published at `2020-04-14T21:04:46Z`, 16 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.6` from `1.0.29`

[Microsoft.NET.Sdk.Functions 3.0.6 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.6)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.12.0` from `4.11.0`
`Microsoft.Identity.Client 4.12.0` was published at `2020-04-23T21:15:18Z`, 7 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.12.0` from `4.11.0`

[Microsoft.Identity.Client 4.12.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.12.0)

NuKeeper has generated a patch update of `Microsoft.Azure.ServiceBus` to `4.1.3` from `4.1.2`
`Microsoft.Azure.ServiceBus 4.1.3` was published at `2020-04-17T21:58:25Z`, 13 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `4.1.3` from `4.1.2`

[Microsoft.Azure.ServiceBus 4.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/4.1.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
