### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Microsoft.Identity.Client`, `Microsoft.NET.Test.Sdk`, `Microsoft.Azure.ServiceBus`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.12.0` from `4.11.0`
`Microsoft.Identity.Client 4.12.0` was published at `2020-04-23T21:15:18Z`, 11 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.12.0` from `4.11.0`

[Microsoft.Identity.Client 4.12.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.12.0)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.6.1` from `16.5.0`
`Microsoft.NET.Test.Sdk 16.6.1` was published at `2020-04-24T09:53:18Z`, 10 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`

[Microsoft.NET.Test.Sdk 16.6.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.6.1)

NuKeeper has generated a patch update of `Microsoft.Azure.ServiceBus` to `4.1.3` from `4.1.2`
`Microsoft.Azure.ServiceBus 4.1.3` was published at `2020-04-17T21:58:25Z`, 17 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `4.1.3` from `4.1.2`

[Microsoft.Azure.ServiceBus 4.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/4.1.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
