### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
3 packages were updated in 2 projects:
`Microsoft.NET.Test.Sdk`, `Microsoft.Azure.ServiceBus`, `Moq`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.6.1` from `16.5.0`
`Microsoft.NET.Test.Sdk 16.6.1` was published at `2020-04-24T09:53:18Z`, 11 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Microsoft.NET.Test.Sdk` `16.6.1` from `16.5.0`

[Microsoft.NET.Test.Sdk 16.6.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.6.1)

NuKeeper has generated a patch update of `Microsoft.Azure.ServiceBus` to `4.1.3` from `4.1.2`
`Microsoft.Azure.ServiceBus 4.1.3` was published at `2020-04-17T21:58:25Z`, 18 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `4.1.3` from `4.1.2`

[Microsoft.Azure.ServiceBus 4.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/4.1.3)

NuKeeper has generated a minor update of `Moq` to `4.14.1` from `4.13.1`
`Moq 4.14.1` was published at `2020-04-28T18:18:20Z`, 7 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Moq` `4.14.1` from `4.13.1`

[Moq 4.14.1 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.1)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
