### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.4.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.4.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Graph`, `Microsoft.NET.Sdk.Functions`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Graph` to `3.4.0` from `1.20.0`
`Microsoft.Graph 3.4.0` was published at `2020-05-01T22:00:40Z`, 10 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.4.0` from `1.20.0`

[Microsoft.Graph 3.4.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.4.0)

NuKeeper has generated a major update of `Microsoft.NET.Sdk.Functions` to `3.0.7` from `1.0.29`
`Microsoft.NET.Sdk.Functions 3.0.7` was published at `2020-05-04T21:59:30Z`, 7 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.7` from `1.0.29`

[Microsoft.NET.Sdk.Functions 3.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.7)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
