### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.NET.Sdk.Functions`, `Microsoft.Identity.Client`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.NET.Sdk.Functions` to `3.0.7` from `1.0.29`
`Microsoft.NET.Sdk.Functions 3.0.7` was published at `2020-05-04T21:59:30Z`, 10 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.7` from `1.0.29`

[Microsoft.NET.Sdk.Functions 3.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.7)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.13.0` from `4.12.0`
`Microsoft.Identity.Client 4.13.0` was published at `2020-05-05T09:05:34Z`, 9 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.13.0` from `4.12.0`

[Microsoft.Identity.Client 4.13.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.13.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
