### PR TITLE
Automatic update of Microsoft.NET.Sdk.Functions to 3.0.7

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.NET.Sdk.Functions` to `3.0.7` from `1.0.29`
`Microsoft.NET.Sdk.Functions 3.0.7` was published at `2020-05-04T21:59:30Z`, 17 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.7` from `1.0.29`

[Microsoft.NET.Sdk.Functions 3.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
