### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.12.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Graph`, `Microsoft.Identity.Client`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Graph` to `3.6.0` from `1.20.0`
`Microsoft.Graph 3.6.0` was published at `2020-05-21T17:11:44Z`, 7 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.6.0` from `1.20.0`

[Microsoft.Graph 3.6.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.6.0)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.14.0` from `4.12.0`
`Microsoft.Identity.Client 4.14.0` was published at `2020-05-19T14:37:52Z`, 9 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.14.0` from `4.12.0`

[Microsoft.Identity.Client 4.14.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.14.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
