### PR TITLE
Automatic update of 4 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
4 packages were updated in 2 projects:
`Microsoft.Graph`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `Moq`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.8.0` from `3.6.0`
`Microsoft.Graph 3.8.0` was published at `2020-06-16T17:54:48Z`, 27 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.8.0` from `3.6.0`

[Microsoft.Graph 3.8.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.8.0)

NuKeeper has generated a patch update of `MSTest.TestAdapter` to `2.1.2` from `2.1.1`
`MSTest.TestAdapter 2.1.2` was published at `2020-06-08T11:13:21Z`, 1 month ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`

[MSTest.TestAdapter 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.2)

NuKeeper has generated a patch update of `MSTest.TestFramework` to `2.1.2` from `2.1.1`
`MSTest.TestFramework 2.1.2` was published at `2020-06-08T11:13:30Z`, 1 month ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`

[MSTest.TestFramework 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.2)

NuKeeper has generated a patch update of `Moq` to `4.14.5` from `4.14.1`
`Moq 4.14.5` was published at `2020-07-01T16:48:50Z`, 12 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Moq` `4.14.5` from `4.14.1`

[Moq 4.14.5 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.5)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
