### PR TITLE
Automatic update of 6 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
   </ItemGroup>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
6 packages were updated in 2 projects:
`Microsoft.Azure.ServiceBus`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.NET.Sdk.Functions`, `Microsoft.NET.Test.Sdk`, `Moq`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Azure.ServiceBus` to `5.0.0` from `4.1.3`
`Microsoft.Azure.ServiceBus 5.0.0` was published at `2020-09-11T20:21:31Z`, 1 month ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `5.0.0` from `4.1.3`

[Microsoft.Azure.ServiceBus 5.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/5.0.0)

NuKeeper has generated a patch update of `MSTest.TestAdapter` to `2.1.2` from `2.1.1`
`MSTest.TestAdapter 2.1.2` was published at `2020-06-08T11:13:21Z`, 4 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`

[MSTest.TestAdapter 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.2)

NuKeeper has generated a patch update of `MSTest.TestFramework` to `2.1.2` from `2.1.1`
`MSTest.TestFramework 2.1.2` was published at `2020-06-08T11:13:30Z`, 4 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`

[MSTest.TestFramework 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.2)

NuKeeper has generated a patch update of `Microsoft.NET.Sdk.Functions` to `3.0.9` from `3.0.7`
`Microsoft.NET.Sdk.Functions 3.0.9` was published at `2020-07-14T01:12:05Z`, 3 months ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.NET.Sdk.Functions` `3.0.9` from `3.0.7`

[Microsoft.NET.Sdk.Functions 3.0.9 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.9)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.7.1` from `16.6.1`
`Microsoft.NET.Test.Sdk 16.7.1` was published at `2020-08-20T09:25:54Z`, 2 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.6.1`

[Microsoft.NET.Test.Sdk 16.7.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.7.1)

NuKeeper has generated a patch update of `Moq` to `4.14.7` from `4.14.1`
`Moq 4.14.7` was published at `2020-10-14T07:16:05Z`, 15 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Moq` `4.14.7` from `4.14.1`

[Moq 4.14.7 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.7)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
