### PR TITLE
Automatic update of 5 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.19.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="3.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.19.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.14.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.22.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
5 packages were updated in 2 projects:
`Microsoft.Azure.ServiceBus`, `MSTest.TestAdapter`, `MSTest.TestFramework`, `Microsoft.Graph`, `Microsoft.Identity.Client`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.Azure.ServiceBus` to `5.0.0` from `4.1.3`
`Microsoft.Azure.ServiceBus 5.0.0` was published at `2020-09-11T20:21:31Z`, 2 months ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Azure.ServiceBus` `5.0.0` from `4.1.3`

[Microsoft.Azure.ServiceBus 5.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.ServiceBus/5.0.0)

NuKeeper has generated a patch update of `MSTest.TestAdapter` to `2.1.2` from `2.1.1`
`MSTest.TestAdapter 2.1.2` was published at `2020-06-08T11:13:21Z`, 5 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestAdapter` `2.1.2` from `2.1.1`

[MSTest.TestAdapter 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestAdapter/2.1.2)

NuKeeper has generated a patch update of `MSTest.TestFramework` to `2.1.2` from `2.1.1`
`MSTest.TestFramework 2.1.2` was published at `2020-06-08T11:13:30Z`, 5 months ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `MSTest.TestFramework` `2.1.2` from `2.1.1`

[MSTest.TestFramework 2.1.2 on NuGet.org](https://www.nuget.org/packages/MSTest.TestFramework/2.1.2)

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.19.0` from `3.6.0`
`Microsoft.Graph 3.19.0` was published at `2020-10-27T18:47:58Z`, 16 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.19.0` from `3.6.0`

[Microsoft.Graph 3.19.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.19.0)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.22.0` from `4.14.0`
`Microsoft.Identity.Client 4.22.0` was published at `2020-10-27T10:42:31Z`, 16 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.22.0` from `4.14.0`

[Microsoft.Identity.Client 4.22.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.22.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
