### PR TITLE
Automatic update of Moq to 4.15.2

### DIFF
--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="Moq" Version="4.15.1" />
+    <PackageReference Include="Moq" Version="4.15.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">


### PR DESCRIPTION
NuKeeper has generated a patch update of `Moq` to `4.15.2` from `4.15.1`
`Moq 4.15.2` was published at `2020-11-26T20:38:49Z`, 7 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Moq` `4.15.2` from `4.15.1`

[Moq 4.15.2 on NuGet.org](https://www.nuget.org/packages/Moq/4.15.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
