### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.8.3

### DIFF
--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `16.8.3` from `16.8.0`
`Microsoft.NET.Test.Sdk 16.8.3` was published at `2020-12-02T22:48:17Z`, 8 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`

[Microsoft.NET.Test.Sdk 16.8.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.8.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
