### PR TITLE
Automatic update of Microsoft.Identity.Client to 4.24.0

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.24.0` from `4.23.0`
`Microsoft.Identity.Client 4.24.0` was published at `2020-12-05T00:17:56Z`, 10 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.24.0` from `4.23.0`

[Microsoft.Identity.Client 4.24.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.24.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
