### PR TITLE
Automatic update of Microsoft.Graph to 3.21.0

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.21.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Graph` to `3.21.0` from `3.20.0`
`Microsoft.Graph 3.21.0` was published at `2020-12-08T21:18:24Z`, 9 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.21.0` from `3.20.0`

[Microsoft.Graph 3.21.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.21.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
