### PR TITLE
Automatic update of 2 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.22.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.22.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
2 packages were updated in 1 project:
`Microsoft.Graph`, `Microsoft.Identity.Client`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.22.0` from `3.20.0`
`Microsoft.Graph 3.22.0` was published at `2021-01-20T22:34:29Z`, 8 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.22.0` from `3.20.0`

[Microsoft.Graph 3.22.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.22.0)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.25.0` from `4.23.0`
`Microsoft.Identity.Client 4.25.0` was published at `2021-01-20T17:24:23Z`, 8 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.25.0` from `4.23.0`

[Microsoft.Identity.Client 4.25.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.25.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
