### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graph" Version="3.20.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.23.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />

--- a/src/AccessFunctions/AccessFunctions.csproj
+++ b/src/AccessFunctions/AccessFunctions.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.23.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.25.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
3 packages were updated in 2 projects:
`coverlet.collector`, `Microsoft.Graph`, `Microsoft.Identity.Client`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `coverlet.collector` to `3.0.2` from `1.3.0`
`coverlet.collector 3.0.2` was published at `2021-01-24T13:16:46Z`, 15 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `coverlet.collector` `3.0.2` from `1.3.0`

[coverlet.collector 3.0.2 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.0.2)

NuKeeper has generated a minor update of `Microsoft.Graph` to `3.23.0` from `3.20.0`
`Microsoft.Graph 3.23.0` was published at `2021-01-29T08:28:21Z`, 10 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Graph` `3.23.0` from `3.20.0`

[Microsoft.Graph 3.23.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Graph/3.23.0)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.25.0` from `4.23.0`
`Microsoft.Identity.Client 4.25.0` was published at `2021-01-20T17:24:23Z`, 19 days ago

1 project update:
Updated `src/AccessFunctions/AccessFunctions.csproj` to `Microsoft.Identity.Client` `4.25.0` from `4.23.0`

[Microsoft.Identity.Client 4.25.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.25.0)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
