### PR TITLE
Automatic update of coverlet.collector to 3.0.2

### DIFF
--- a/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
+++ b/tests/AccessFunctionsTests/AccessFunctionsTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a major update of `coverlet.collector` to `3.0.2` from `1.3.0`
`coverlet.collector 3.0.2` was published at `2021-01-24T13:16:46Z`, 18 days ago

1 project update:
Updated `tests/AccessFunctionsTests/AccessFunctionsTests.csproj` to `coverlet.collector` `3.0.2` from `1.3.0`

[coverlet.collector 3.0.2 on NuGet.org](https://www.nuget.org/packages/coverlet.collector/3.0.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
